### PR TITLE
Add staff-only Discord bot implementation for «Пехота Зенита»

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DISCORD_TOKEN=your_token_here
+CLIENT_ID=your_app_client_id

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Discord бот «Пехота Зенита» (стафф)
+
+## Требования
+- Node.js 18+
+- discord.js v14
+- SQLite (локальный файл `staff.db`)
+
+## Интенты
+- Guilds
+- GuildMembers
+- GuildModeration
+- GuildMessages
+- GuildVoiceStates
+
+## Права бота
+- Manage Roles
+- Moderate Members
+- Send Messages
+- View Channels
+
+**Важно:** роль бота должна быть выше всех стафф-ролей.
+
+## Установка
+```bash
+npm i
+```
+
+## Настройка
+1) Создайте `.env` на основе `.env.example`:
+```env
+DISCORD_TOKEN=ваш_токен
+CLIENT_ID=app_client_id
+```
+2) Проверьте `config.yml` (все ID уже заполнены).
+
+## Регистрация команд
+```bash
+npm run register
+```
+
+## Запуск
+```bash
+node src/index.js
+```
+
+## Логи
+- Логи пишутся в `logs/bot-YYYY-MM-DD.log`
+- Все события системы пишутся в `STAFF_JOURNAL`

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,178 @@
+guildId: "1441421295848915056"
+channels:
+  staffChat: "1441421300814975061"
+  staffJournal: "1441421301217624164"
+roles:
+  ladder:
+    - key: candidate
+      name: "Кандидат"
+      roleId: "1469270989861818495"
+    - key: trainee
+      name: "Стажёр"
+      roleId: "1469271081574600736"
+    - key: junior_helper
+      name: "Младший помощник"
+      roleId: "1441421296373207137"
+    - key: helper
+      name: "Помощник"
+      roleId: "1469271540485980275"
+    - key: senior_helper
+      name: "Старший помощник"
+      roleId: "1469271670966714409"
+    - key: junior_moderator
+      name: "Младший модератор"
+      roleId: "1441421296373207139"
+    - key: moderator
+      name: "Модератор"
+      roleId: "1441421296390111264"
+    - key: senior_moderator
+      name: "Старший модератор"
+      roleId: "1469273818861142180"
+    - key: deputy_curator
+      name: "Заместитель куратора"
+      roleId: "1441421296390111266"
+    - key: curator
+      name: "Куратор"
+      roleId: "1441421296390111267"
+    - key: chief_curator
+      name: "Главный куратор"
+      roleId: "1469274200861573226"
+    - key: junior_admin
+      name: "Младший администратор"
+      roleId: "1441421296390111270"
+    - key: admin
+      name: "Администратор"
+      roleId: "1441421296390111271"
+    - key: senior_admin
+      name: "Старший администратор"
+      roleId: "1469274655348097191"
+    - key: head_admin
+      name: "Главный администратор"
+      roleId: "1469274879458017331"
+accessMatrix:
+  profile_me: candidate
+  profile_user: senior_helper
+  shop_open: candidate
+  shop_inventory: candidate
+  shop_log: senior_moderator
+  shop_active: senior_moderator
+  shop_revoke: senior_admin
+  promo_request: trainee
+  promo_list: senior_helper
+  promo_approve: deputy_curator
+  promo_deny: deputy_curator
+  promo_promote: curator
+  promo_demote: curator
+  panel_send: senior_moderator
+  sp_add: senior_moderator
+  sp_remove: senior_moderator
+  sp_set: senior_moderator
+  sp_log: senior_moderator
+  sp_top: senior_moderator
+  sp_penalty: senior_moderator
+  coins_add: senior_moderator
+  coins_remove: senior_moderator
+  coins_set: senior_moderator
+  coins_log: senior_moderator
+  coins_top: senior_moderator
+  punish_mute: senior_moderator
+  punish_ban: senior_moderator
+  punish_revoke: senior_moderator
+  punish_log: senior_moderator
+  warnings_list: senior_moderator
+  warnings_add: senior_moderator
+  warnings_remove: senior_moderator
+  config_reload: admin
+  health: admin
+  backup_export: admin
+  backup_import: head_admin
+  ticket_done: senior_moderator
+  ticket_deny: curator
+  ticket_refund: curator
+promotions:
+  table:
+    trainee:
+      to: junior_helper
+      sp: 10
+      days: 2
+    junior_helper:
+      to: helper
+      sp: 25
+      days: 5
+    helper:
+      to: senior_helper
+      sp: 40
+      days: 7
+    senior_helper:
+      to: junior_moderator
+      sp: 65
+      days: 10
+    junior_moderator:
+      to: moderator
+      sp: 90
+      days: 12
+    moderator:
+      to: senior_moderator
+      sp: 130
+      days: 15
+    senior_moderator:
+      to: deputy_curator
+      sp: 180
+      days: 18
+    deputy_curator:
+      to: curator
+      sp: 230
+      days: 20
+    curator:
+      to: chief_curator
+      sp: 290
+      days: 25
+    chief_curator:
+      to: junior_admin
+      sp: 360
+      days: 30
+    junior_admin:
+      to: admin
+      sp: 430
+      days: 35
+    admin:
+      to: senior_admin
+      sp: 520
+      days: 45
+punish:
+  limits:
+    mute:
+      junior_moderator: "30m"
+      moderator: "2h"
+      senior_moderator: "24h"
+      deputy_curator: "perm"
+    ban:
+      senior_moderator: "24h"
+      deputy_curator: "72h"
+      curator: "7d"
+      chief_curator: "perm"
+shop:
+  items:
+    custom_role_7d:
+      type: AUTO
+      name: "Кастом роль (7 дней)"
+      price: 250
+      durationDays: 7
+    color_role_7d:
+      type: TICKET
+      name: "Цвет роли (7 дней)"
+      price: 120
+      durationDays: 7
+    custom_tag_7d:
+      type: TICKET
+      name: "Кастом тег (7 дней)"
+      price: 150
+      durationDays: 7
+coins:
+  dailySoftLimit: 80
+warnings:
+  expireDays: 14
+autoPromoteMode: request
+autoCreateRequestOnEligible: false
+sameTargetCooldownHours: 24
+metaTypeDailyLimit: 3

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "zenit-infantry-staff-bot",
+  "version": "1.0.0",
+  "description": "Staff-only Discord bot for \"Пехота Зенита\" server",
+  "main": "src/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/index.js",
+    "register": "node src/registerCommands.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^9.4.1",
+    "discord.js": "^14.15.3",
+    "dotenv": "^16.4.5",
+    "yaml": "^2.4.5"
+  }
+}

--- a/src/commands/backup.js
+++ b/src/commands/backup.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { successEmbed, errorEmbed } = require('../utils/embeds');
+const { getConfig } = require('../config');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('backup')
+    .setDescription('Бэкап базы данных')
+    .addSubcommand((sub) => sub.setName('export').setDescription('Экспорт БД'))
+    .addSubcommand((sub) => sub.setName('import').setDescription('Импорт БД')),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'export') {
+      const check = assertStaff(interaction.member, 'backup_export');
+      if (!check.ok) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+      }
+      const config = getConfig();
+      const dbPath = path.join(__dirname, '..', '..', 'staff.db');
+      const buffer = fs.readFileSync(dbPath);
+      const attachment = new AttachmentBuilder(buffer, { name: `staff-backup-${Date.now()}.db` });
+      const journal = await interaction.client.channels.fetch(config.channels.staffJournal);
+      await journal.send({ content: 'Экспорт базы данных.', files: [attachment] });
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Бэкап отправлен в журнал.')] });
+    }
+    if (sub === 'import') {
+      const check = assertStaff(interaction.member, 'backup_import');
+      if (!check.ok) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+      }
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Отключено').setDescription('Импорт пока не реализован.')] });
+    }
+    return null;
+  },
+};

--- a/src/commands/coins.js
+++ b/src/commands/coins.js
@@ -1,0 +1,93 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff, getStaffRank, getRankByRoleKey } = require('../utils/permissions');
+const { successEmbed, errorEmbed, infoEmbed } = require('../utils/embeds');
+const coinsService = require('../services/coinsService');
+const logger = require('../logger');
+const { getConfig } = require('../config');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('coins')
+    .setDescription('Управление Coins')
+    .addSubcommand((sub) => sub
+      .setName('add')
+      .setDescription('Начислить Coins')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addIntegerOption((opt) => opt.setName('value').setDescription('Количество').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('remove')
+      .setDescription('Списать Coins')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addIntegerOption((opt) => opt.setName('value').setDescription('Количество').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('set')
+      .setDescription('Установить Coins')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addIntegerOption((opt) => opt.setName('value').setDescription('Количество').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('log')
+      .setDescription('Лог Coins')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(false)))
+    .addSubcommand((sub) => sub
+      .setName('top')
+      .setDescription('Топ Coins')),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const accessKey = `coins_${sub}`;
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+
+    if (['add', 'remove', 'set'].includes(sub)) {
+      const target = interaction.options.getUser('user');
+      if (target.id === interaction.user.id) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Нельзя начислять себе.')] });
+      }
+      const value = interaction.options.getInteger('value');
+      const reason = interaction.options.getString('reason');
+      if (sub === 'add') {
+        const softLimitExceeded = coinsService.checkSoftLimit(interaction.user.id, value);
+        coinsService.adjustCoins({ actorId: interaction.user.id, targetId: target.id, delta: value, reason, kind: 'manual' });
+        if (softLimitExceeded) {
+          logger.warn(`Coins daily soft limit exceeded by ${interaction.user.id}.`);
+          const config = getConfig();
+          const channel = await interaction.client.channels.fetch(config.channels.staffJournal);
+          await channel.send({ embeds: [infoEmbed('⚠ Превышен лимит Coins').setDescription(`Актёр: <@${interaction.user.id}>\\nDelta: +${value}`)] });
+        }
+        return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`Coins +${value}.`)] });
+      }
+      if (sub === 'remove') {
+        coinsService.adjustCoins({ actorId: interaction.user.id, targetId: target.id, delta: -value, reason, kind: 'manual' });
+        return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`Coins -${value}.`)] });
+      }
+      if (sub === 'set') {
+        coinsService.setCoins({ actorId: interaction.user.id, targetId: target.id, value, reason });
+        return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`Coins = ${value}.`)] });
+      }
+    }
+
+    if (sub === 'log') {
+      const target = interaction.options.getUser('user');
+      const deputyRank = getRankByRoleKey('deputy_curator');
+      const memberRank = getStaffRank(interaction.member);
+      if (!target || (target.id !== interaction.user.id && memberRank < deputyRank)) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription('Просмотр всех логов доступен только Зам.куратора+.')] });
+      }
+      const rows = coinsService.listCoinsLog(20, target?.id ?? null);
+      const description = rows.map((row) => `#${row.id} <@${row.targetId}> ${row.delta} (${row.reason})`).join('\n') || 'Нет данных.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Лог Coins').setDescription(description)] });
+    }
+
+    if (sub === 'top') {
+      const top = coinsService.topCoins(10);
+      const description = top.map((row, idx) => `**${idx + 1}.** <@${row.userId}> — ${row.coins} Coins`).join('\n') || 'Нет данных.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Топ Coins').setDescription(description)] });
+    }
+
+    return null;
+  },
+};

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,0 +1,24 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { successEmbed, errorEmbed, infoEmbed } = require('../utils/embeds');
+const { loadConfig } = require('../config');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('config')
+    .setDescription('Админ команды')
+    .addSubcommand((sub) => sub.setName('reload').setDescription('Перезагрузить конфиг')),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'reload') {
+      const check = assertStaff(interaction.member, 'config_reload');
+      if (!check.ok) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+      }
+      loadConfig();
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Конфиг обновлён.')] });
+    }
+
+    return null;
+  },
+};

--- a/src/commands/health.js
+++ b/src/commands/health.js
@@ -1,0 +1,16 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { infoEmbed, errorEmbed } = require('../utils/embeds');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('health')
+    .setDescription('Проверка состояния бота'),
+  async execute(interaction) {
+    const check = assertStaff(interaction.member, 'health');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    return interaction.reply({ ephemeral: true, embeds: [infoEmbed('OK').setDescription('Бот работает.')] });
+  },
+};

--- a/src/commands/panel.js
+++ b/src/commands/panel.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { errorEmbed, successEmbed } = require('../utils/embeds');
+const { getConfig } = require('../config');
+const { buildPanelMessage } = require('../panel/panelMessage');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('panel')
+    .setDescription('Панель стаффа')
+    .addSubcommand((sub) => sub.setName('send').setDescription('Отправить панель')),
+  async execute(interaction) {
+    const check = assertStaff(interaction.member, 'panel_send');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const config = getConfig();
+    const staffChat = await interaction.client.channels.fetch(config.channels.staffChat);
+    const payload = buildPanelMessage();
+    await staffChat.send(payload);
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Панель отправлена.')] });
+  },
+};

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { infoEmbed, errorEmbed } = require('../utils/embeds');
+const pointsService = require('../services/pointsService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('profile')
+    .setDescription('Профиль стаффа')
+    .addSubcommand((sub) => sub
+      .setName('me')
+      .setDescription('Показать свой профиль'))
+    .addSubcommand((sub) => sub
+      .setName('user')
+      .setDescription('Показать профиль пользователя')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const accessKey = sub === 'me' ? 'profile_me' : 'profile_user';
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+
+    const user = sub === 'me'
+      ? interaction.user
+      : interaction.options.getUser('user');
+    const data = pointsService.getUser(user.id);
+    const embed = infoEmbed('Профиль')
+      .setDescription(`Пользователь: <@${user.id}>\nSP: **${data.sp}**\nCoins: **${data.coins}**`);
+    return interaction.reply({ ephemeral: true, embeds: [embed] });
+  },
+};

--- a/src/commands/promo.js
+++ b/src/commands/promo.js
@@ -1,0 +1,112 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { successEmbed, errorEmbed, infoEmbed } = require('../utils/embeds');
+const promoService = require('../services/promoService');
+const { getConfig } = require('../config');
+const { setStaffRole } = require('../services/pointsService');
+
+async function applyRoleChange(guild, userId, newRoleId) {
+  const member = await guild.members.fetch(userId);
+  const config = getConfig();
+  const ladderRoleIds = config.roles.ladder.map((r) => r.roleId);
+  const rolesToRemove = member.roles.cache.filter((role) => ladderRoleIds.includes(role.id));
+  if (rolesToRemove.size > 0) {
+    await member.roles.remove(rolesToRemove, 'Смена стафф роли');
+  }
+  if (newRoleId) {
+    await member.roles.add(newRoleId, 'Смена стафф роли');
+  }
+  setStaffRole(userId, newRoleId, Date.now());
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('promo')
+    .setDescription('Повышения')
+    .addSubcommand((sub) => sub
+      .setName('request')
+      .setDescription('Запросить повышение'))
+    .addSubcommand((sub) => sub
+      .setName('list')
+      .setDescription('Список заявок'))
+    .addSubcommand((sub) => sub
+      .setName('approve')
+      .setDescription('Одобрить заявку')
+      .addIntegerOption((opt) => opt.setName('id').setDescription('ID заявки').setRequired(true))
+      .addStringOption((opt) => opt.setName('note').setDescription('Комментарий').setRequired(false)))
+    .addSubcommand((sub) => sub
+      .setName('deny')
+      .setDescription('Отклонить заявку')
+      .addIntegerOption((opt) => opt.setName('id').setDescription('ID заявки').setRequired(true))
+      .addStringOption((opt) => opt.setName('note').setDescription('Комментарий').setRequired(false)))
+    .addSubcommand((sub) => sub
+      .setName('promote')
+      .setDescription('Ручное повышение')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addStringOption((opt) => opt.setName('role').setDescription('roleKey').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('demote')
+      .setDescription('Ручное понижение')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addStringOption((opt) => opt.setName('role').setDescription('roleKey').setRequired(true))),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const accessKey = `promo_${sub}`;
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+
+    if (sub === 'request') {
+      const result = promoService.createRequest(interaction.user.id);
+      if (!result.ok) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription(result.reason)] });
+      }
+      const config = getConfig();
+      const journal = await interaction.client.channels.fetch(config.channels.staffJournal);
+      const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId(`promo_approve:${result.requestId}`).setLabel('✅ Одобрить').setStyle(ButtonStyle.Success),
+        new ButtonBuilder().setCustomId(`promo_deny:${result.requestId}`).setLabel('❌ Отказать').setStyle(ButtonStyle.Danger)
+      );
+      await journal.send({
+        embeds: [infoEmbed('Заявка на повышение').setDescription(`Пользователь: <@${interaction.user.id}>\\nID: ${result.requestId}`)],
+        components: [row],
+      });
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Заявка создана').setDescription(`ID заявки: ${result.requestId}`)] });
+    }
+
+    if (sub === 'list') {
+      const list = promoService.listRequests('pending');
+      const description = list.map((req) => `#${req.id} <@${req.userId}>`).join('\n') || 'Нет заявок.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Заявки').setDescription(description)] });
+    }
+
+    if (sub === 'approve' || sub === 'deny') {
+      const id = interaction.options.getInteger('id');
+      const note = interaction.options.getString('note') || '';
+      const request = promoService.getRequest(id);
+      if (!request) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Заявка не найдена.')] });
+      }
+      promoService.reviewRequest(id, interaction.user.id, sub === 'approve' ? 'approved' : 'denied', note);
+      if (sub === 'approve') {
+        await applyRoleChange(interaction.guild, request.userId, request.toRoleId);
+      }
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription('Заявка обработана.')] });
+    }
+
+    if (sub === 'promote' || sub === 'demote') {
+      const user = interaction.options.getUser('user');
+      const roleKey = interaction.options.getString('role');
+      const config = getConfig();
+      const role = config.roles.ladder.find((r) => r.key === roleKey);
+      if (!role) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Неизвестный roleKey.')] });
+      }
+      await applyRoleChange(interaction.guild, user.id, role.roleId);
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`Роль обновлена: ${role.name}.`)] });
+    }
+
+    return null;
+  },
+};

--- a/src/commands/punish.js
+++ b/src/commands/punish.js
@@ -1,0 +1,106 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff, getStaffRank, getRoleKeyByRank } = require('../utils/permissions');
+const { successEmbed, errorEmbed, infoEmbed } = require('../utils/embeds');
+const punishService = require('../services/punishService');
+const { parseDuration } = require('../utils/timeParse');
+const logger = require('../logger');
+const { getConfig } = require('../config');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('punish')
+    .setDescription('Наказания')
+    .addSubcommand((sub) => sub
+      .setName('mute')
+      .setDescription('Мут')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addStringOption((opt) => opt.setName('duration').setDescription('Длительность').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('ban')
+      .setDescription('Бан')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addStringOption((opt) => opt.setName('duration').setDescription('Длительность').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true))
+      .addStringOption((opt) => opt.setName('proof').setDescription('Доказательство').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('revoke')
+      .setDescription('Отменить наказание')
+      .addIntegerOption((opt) => opt.setName('case').setDescription('ID кейса').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('log')
+      .setDescription('Лог наказаний')),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const accessKey = `punish_${sub}`;
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+
+    if (sub === 'log') {
+      const rows = punishService.listCases(20);
+      const description = rows.map((row) => `#${row.id} <@${row.targetId}> ${row.action} ${row.durationMinutes || 'perm'}m`).join('\n') || 'Нет данных.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Лог наказаний').setDescription(description)] });
+    }
+
+    if (sub === 'revoke') {
+      const caseId = interaction.options.getInteger('case');
+      const reason = interaction.options.getString('reason');
+      punishService.revokeCase(caseId, interaction.user.id, reason);
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription('Кейс отозван.')] });
+    }
+
+    if (sub === 'mute' || sub === 'ban') {
+      const target = interaction.options.getUser('user');
+      const duration = interaction.options.getString('duration');
+      const reason = interaction.options.getString('reason');
+      const proof = sub === 'ban' ? interaction.options.getString('proof') : '';
+      const roleKey = getRoleKeyByRank(getStaffRank(interaction.member));
+      const limitCheck = punishService.checkLimit(roleKey, sub, duration);
+      if (!limitCheck.ok) {
+        logger.warn(`Limit exceeded by ${interaction.user.id}.`);
+        const config = getConfig();
+        const channel = await interaction.client.channels.fetch(config.channels.staffJournal);
+        await channel.send({ embeds: [errorEmbed('Превышение лимита наказания').setDescription(`Актёр: <@${interaction.user.id}>\\nТип: ${sub}\\nДлительность: ${duration}`)] });
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Отказ').setDescription(limitCheck.reason)] });
+      }
+      const parsed = parseDuration(duration);
+      if (sub === 'mute') {
+        const member = await interaction.guild.members.fetch(target.id).catch(() => null);
+        if (!member) {
+          return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Пользователь не найден.')] });
+        }
+        if (parsed.isPerm || parsed.minutes === null) {
+          return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Неверная длительность.')] });
+        }
+        await member.timeout(parsed.minutes * 60 * 1000, reason);
+      } else {
+        await interaction.guild.members.ban(target.id, { reason });
+      }
+      const caseId = punishService.logCase({
+        actorId: interaction.user.id,
+        targetId: target.id,
+        action: sub,
+        durationMinutes: parsed.minutes,
+        isPerm: parsed.isPerm,
+        reason,
+        proof,
+      });
+      const spAward = punishService.awardPunishSp({
+        actorId: interaction.user.id,
+        targetId: target.id,
+        action: sub,
+        minutes: parsed.minutes,
+        isPerm: parsed.isPerm,
+        proof,
+        logger,
+      });
+      const extra = spAward.awarded ? `\nSP: +${spAward.sp}` : '';
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Наказание применено').setDescription(`Кейс #${caseId}${extra}`)] });
+    }
+
+    return null;
+  },
+};

--- a/src/commands/shop.js
+++ b/src/commands/shop.js
@@ -1,0 +1,70 @@
+const { SlashCommandBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { infoEmbed, errorEmbed } = require('../utils/embeds');
+const shopService = require('../services/shopService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('shop')
+    .setDescription('Магазин стаффа')
+    .addSubcommand((sub) => sub.setName('open').setDescription('Открыть магазин'))
+    .addSubcommand((sub) => sub.setName('inventory').setDescription('Мои покупки'))
+    .addSubcommand((sub) => sub.setName('log').setDescription('Логи покупок'))
+    .addSubcommand((sub) => sub.setName('active').setDescription('Активные покупки'))
+    .addSubcommand((sub) => sub
+      .setName('revoke')
+      .setDescription('Откат покупки')
+      .addIntegerOption((opt) => opt.setName('purchase').setDescription('ID покупки').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true))),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const accessKey = `shop_${sub}`;
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+
+    if (sub === 'open') {
+      const items = shopService.getItems();
+      const options = Object.entries(items).map(([key, item]) => ({
+        label: `${item.name} (${item.price} Coins)`,
+        value: key,
+      }));
+      const row = new ActionRowBuilder().addComponents(
+        new StringSelectMenuBuilder().setCustomId('shop_select').setPlaceholder('Выберите товар').addOptions(options)
+      );
+      const description = Object.entries(items).map(([key, item]) => `• **${item.name}** — ${item.price} Coins (key: ${key})`).join('\n');
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Магазин').setDescription(description)], components: [row] });
+    }
+
+    if (sub === 'inventory') {
+      const list = shopService.listPurchases(null, 20).filter((p) => p.userId === interaction.user.id);
+      const description = list.map((p) => `#${p.id} ${p.itemKey} — ${p.status}`).join('\n') || 'Нет покупок.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Мои покупки').setDescription(description)] });
+    }
+
+    if (sub === 'log') {
+      const list = shopService.listPurchases(null, 20);
+      const description = list.map((p) => `#${p.id} <@${p.userId}> ${p.itemKey} — ${p.status}`).join('\n') || 'Нет данных.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Лог магазина').setDescription(description)] });
+    }
+
+    if (sub === 'active') {
+      const list = shopService.listActivePurchases(20);
+      const description = list.map((p) => `#${p.id} <@${p.userId}> ${p.itemKey} до ${p.expiresAt || 'n/a'}`).join('\n') || 'Нет активных.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Активные покупки').setDescription(description)] });
+    }
+
+    if (sub === 'revoke') {
+      const purchaseId = interaction.options.getInteger('purchase');
+      const reason = interaction.options.getString('reason');
+      const result = shopService.revokePurchase(purchaseId, interaction.user.id, reason);
+      if (!result.ok) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription(result.reason)] });
+      }
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Откат выполнен').setDescription('Покупка откачена и Coins возвращены.')] });
+    }
+
+    return null;
+  },
+};

--- a/src/commands/sp.js
+++ b/src/commands/sp.js
@@ -1,0 +1,113 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff, getStaffRank, getRankByRoleKey } = require('../utils/permissions');
+const { successEmbed, errorEmbed, infoEmbed } = require('../utils/embeds');
+const pointsService = require('../services/pointsService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('sp')
+    .setDescription('Управление SP')
+    .addSubcommand((sub) => sub
+      .setName('add')
+      .setDescription('Начислить SP')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addIntegerOption((opt) => opt.setName('value').setDescription('Количество').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true))
+      .addStringOption((opt) => opt.setName('meta').setDescription('metaType').setRequired(false)))
+    .addSubcommand((sub) => sub
+      .setName('remove')
+      .setDescription('Списать SP')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addIntegerOption((opt) => opt.setName('value').setDescription('Количество').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('set')
+      .setDescription('Установить SP')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addIntegerOption((opt) => opt.setName('value').setDescription('Количество').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('log')
+      .setDescription('Лог SP')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(false)))
+    .addSubcommand((sub) => sub
+      .setName('top')
+      .setDescription('Топ SP'))
+    .addSubcommand((sub) => sub
+      .setName('penalty')
+      .setDescription('Штраф SP')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addStringOption((opt) => opt.setName('type').setDescription('Тип').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true))),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const accessKey = `sp_${sub}`;
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+
+    if (['add', 'remove', 'set', 'penalty'].includes(sub)) {
+      const target = interaction.options.getUser('user');
+      if (target.id === interaction.user.id) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Нельзя начислять себе.')] });
+      }
+      const reason = interaction.options.getString('reason');
+
+      if (sub === 'penalty') {
+        const type = interaction.options.getString('type');
+        const penalties = {
+          ignore: -5,
+          rude: -6,
+          wrong_punish: -8,
+          confirmed_complaint: -12,
+          abuse_power: -25,
+        };
+        const delta = penalties[type];
+        if (!delta) {
+          return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Неизвестный тип штрафа.')] });
+        }
+        pointsService.adjustSp({ actorId: interaction.user.id, targetId: target.id, delta, reason, kind: 'penalty', metaType: type });
+        return interaction.reply({ ephemeral: true, embeds: [successEmbed('Штраф применён').setDescription(`SP ${delta}.`)] });
+      }
+
+      const value = interaction.options.getInteger('value');
+      if (sub === 'add') {
+        const metaType = interaction.options.getString('meta') || '';
+        if (metaType && !pointsService.canAwardMeta(interaction.user.id, metaType)) {
+          return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Дневной лимит по metaType исчерпан.')] });
+        }
+        pointsService.adjustSp({ actorId: interaction.user.id, targetId: target.id, delta: value, reason, kind: 'manual', metaType });
+        return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`SP +${value}.`)] });
+      }
+      if (sub === 'remove') {
+        pointsService.adjustSp({ actorId: interaction.user.id, targetId: target.id, delta: -value, reason, kind: 'manual' });
+        return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`SP -${value}.`)] });
+      }
+      if (sub === 'set') {
+        pointsService.setSp({ actorId: interaction.user.id, targetId: target.id, value, reason });
+        return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`SP = ${value}.`)] });
+      }
+    }
+
+    if (sub === 'log') {
+      const target = interaction.options.getUser('user');
+      const deputyRank = getRankByRoleKey('deputy_curator');
+      const memberRank = getStaffRank(interaction.member);
+      if (!target || (target.id !== interaction.user.id && memberRank < deputyRank)) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription('Просмотр всех логов доступен только Зам.куратора+.')] });
+      }
+      const rows = pointsService.listSpLog(20, target?.id ?? null);
+      const description = rows.map((row) => `#${row.id} <@${row.targetId}> ${row.delta} (${row.reason})`).join('\n') || 'Нет данных.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Лог SP').setDescription(description)] });
+    }
+
+    if (sub === 'top') {
+      const top = pointsService.topSp(10);
+      const description = top.map((row, idx) => `**${idx + 1}.** <@${row.userId}> — ${row.sp} SP`).join('\n') || 'Нет данных.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Топ SP').setDescription(description)] });
+    }
+
+    return null;
+  },
+};

--- a/src/commands/warnings.js
+++ b/src/commands/warnings.js
@@ -1,0 +1,55 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { assertStaff } = require('../utils/permissions');
+const { infoEmbed, successEmbed, errorEmbed } = require('../utils/embeds');
+const warningsService = require('../services/warningsService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('warnings')
+    .setDescription('Предупреждения')
+    .addSubcommand((sub) => sub
+      .setName('list')
+      .setDescription('Список предупреждений')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(false)))
+    .addSubcommand((sub) => sub
+      .setName('add')
+      .setDescription('Добавить предупреждение')
+      .addUserOption((opt) => opt.setName('user').setDescription('Пользователь').setRequired(true))
+      .addStringOption((opt) => opt.setName('type').setDescription('Тип').setRequired(true))
+      .addStringOption((opt) => opt.setName('reason').setDescription('Причина').setRequired(true)))
+    .addSubcommand((sub) => sub
+      .setName('remove')
+      .setDescription('Удалить предупреждение')
+      .addIntegerOption((opt) => opt.setName('id').setDescription('ID предупреждения').setRequired(true))),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    const accessKey = `warnings_${sub}`;
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+
+    if (sub === 'list') {
+      const user = interaction.options.getUser('user');
+      const list = warningsService.listWarnings(user?.id ?? null);
+      const description = list.map((w) => `#${w.id} <@${w.userId}> ${w.type} (${w.reason})`).join('\n') || 'Нет предупреждений.';
+      return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Предупреждения').setDescription(description)] });
+    }
+
+    if (sub === 'add') {
+      const user = interaction.options.getUser('user');
+      const type = interaction.options.getString('type');
+      const reason = interaction.options.getString('reason');
+      warningsService.addWarning({ actorId: interaction.user.id, userId: user.id, type, reason });
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Предупреждение добавлено.')] });
+    }
+
+    if (sub === 'remove') {
+      const id = interaction.options.getInteger('id');
+      warningsService.removeWarning(id);
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Предупреждение удалено.')] });
+    }
+
+    return null;
+  },
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+
+let cachedConfig = null;
+
+function loadConfig() {
+  const configPath = path.join(__dirname, '..', 'config.yml');
+  const raw = fs.readFileSync(configPath, 'utf8');
+  cachedConfig = YAML.parse(raw);
+  return cachedConfig;
+}
+
+function getConfig() {
+  if (!cachedConfig) {
+    return loadConfig();
+  }
+  return cachedConfig;
+}
+
+module.exports = {
+  loadConfig,
+  getConfig,
+};

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,107 @@
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const dbPath = path.join(__dirname, '..', 'staff.db');
+const db = new Database(dbPath);
+
+function initDb() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users(
+      userId TEXT PRIMARY KEY,
+      sp INTEGER DEFAULT 0,
+      coins INTEGER DEFAULT 0,
+      currentStaffRoleId TEXT,
+      staffRoleSince INTEGER,
+      joinedAt INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS warnings(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      userId TEXT,
+      type TEXT,
+      reason TEXT,
+      createdAt INTEGER,
+      expiresAt INTEGER,
+      actorId TEXT
+    );
+    CREATE TABLE IF NOT EXISTS sp_log(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER,
+      actorId TEXT,
+      targetId TEXT,
+      delta INTEGER,
+      reason TEXT,
+      proof TEXT,
+      kind TEXT,
+      metaType TEXT
+    );
+    CREATE TABLE IF NOT EXISTS coins_log(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER,
+      actorId TEXT,
+      targetId TEXT,
+      delta INTEGER,
+      reason TEXT,
+      kind TEXT
+    );
+    CREATE TABLE IF NOT EXISTS punish_cases(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER,
+      actorId TEXT,
+      targetId TEXT,
+      action TEXT,
+      durationMinutes INTEGER,
+      isPerm INTEGER,
+      reason TEXT,
+      proof TEXT,
+      revoked INTEGER,
+      revokedAt INTEGER,
+      revokedReason TEXT
+    );
+    CREATE TABLE IF NOT EXISTS punish_sp_counters(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actorId TEXT,
+      dayKey TEXT,
+      mutesCount INTEGER,
+      bansCount INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS promo_requests(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER,
+      userId TEXT,
+      fromRoleId TEXT,
+      toRoleId TEXT,
+      spAt INTEGER,
+      daysAt INTEGER,
+      status TEXT,
+      reviewerId TEXT,
+      reviewedAt INTEGER,
+      note TEXT
+    );
+    CREATE TABLE IF NOT EXISTS shop_purchases(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER,
+      userId TEXT,
+      itemKey TEXT,
+      price INTEGER,
+      status TEXT,
+      detailsJson TEXT,
+      expiresAt INTEGER,
+      roleId TEXT,
+      ticketMessageId TEXT,
+      ticketThreadId TEXT,
+      handledBy TEXT,
+      handledAt INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS shop_cooldowns(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      userId TEXT,
+      itemKey TEXT,
+      lastBuyAt INTEGER
+    );
+  `);
+}
+
+module.exports = {
+  db,
+  initDb,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,366 @@
+require('dotenv').config();
+const {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  Collection,
+  Events,
+  ActionRowBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+} = require('discord.js');
+const { loadConfig, getConfig } = require('./config');
+const logger = require('./logger');
+const { initDb, db } = require('./db');
+const { assertStaff, getStaffRank, getRoleKeyByRank } = require('./utils/permissions');
+const { infoEmbed, successEmbed, errorEmbed } = require('./utils/embeds');
+const profile = require('./commands/profile');
+const sp = require('./commands/sp');
+const coins = require('./commands/coins');
+const promo = require('./commands/promo');
+const punish = require('./commands/punish');
+const warnings = require('./commands/warnings');
+const shop = require('./commands/shop');
+const panel = require('./commands/panel');
+const configCmd = require('./commands/config');
+const backup = require('./commands/backup');
+const health = require('./commands/health');
+const { handlePanelButton, handlePanelModal, handlePanelSelect } = require('./panel/handlers');
+const pointsService = require('./services/pointsService');
+const coinsService = require('./services/coinsService');
+const promoService = require('./services/promoService');
+const warningsService = require('./services/warningsService');
+const shopService = require('./services/shopService');
+const ticketService = require('./services/ticketService');
+const { createCustomRole, removeCustomRole } = require('./services/customRoleService');
+
+const commands = [profile, sp, coins, promo, punish, warnings, shop, panel, configCmd, backup, health];
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildModeration,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.GuildVoiceStates,
+  ],
+  partials: [Partials.Channel],
+});
+
+client.commands = new Collection();
+for (const command of commands) {
+  client.commands.set(command.data.name, command);
+}
+
+function buildModal(customId, title, inputs) {
+  const modal = new ModalBuilder().setCustomId(customId).setTitle(title);
+  const rows = inputs.map((input) => new ActionRowBuilder().addComponents(input));
+  modal.addComponents(...rows);
+  return modal;
+}
+
+async function sendStaffLog(clientRef, embed) {
+  const config = getConfig();
+  const channel = await clientRef.channels.fetch(config.channels.staffJournal).catch(() => null);
+  if (channel) {
+    await channel.send({ embeds: [embed] });
+  }
+}
+
+async function ensureStaffRoleRecord(member) {
+  const rank = getStaffRank(member);
+  if (rank < 0) return;
+  const config = getConfig();
+  const roleId = config.roles.ladder[rank].roleId;
+  pointsService.setStaffRole(member.id, roleId, Date.now());
+}
+
+async function handleShopSelect(interaction) {
+  const check = assertStaff(interaction.member, 'shop_open');
+  if (!check.ok) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+  }
+  const itemKey = interaction.values[0];
+  const items = shopService.getItems();
+  const item = items[itemKey];
+  if (!item) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Товар не найден.')] });
+  }
+  const userData = pointsService.getUser(interaction.user.id);
+  if (userData.coins < item.price) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Недостаточно Coins').setDescription('Пополните баланс.')] });
+  }
+
+  if (itemKey === 'custom_role_7d' && shopService.hasActivePurchase(interaction.user.id, itemKey)) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('У вас уже есть активная кастом роль.')] });
+  }
+
+  if (item.type === 'AUTO') {
+    const modal = buildModal(`shop_auto:${itemKey}`, 'Кастом роль', [
+      new TextInputBuilder().setCustomId('roleName').setLabel('Название роли').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('hexColor').setLabel('HEX цвет (#ff0000)').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('iconLink').setLabel('Ссылка на иконку').setStyle(TextInputStyle.Short).setRequired(false),
+    ]);
+    return interaction.showModal(modal);
+  }
+
+  if (item.type === 'TICKET') {
+    const modal = buildModal(`shop_ticket:${itemKey}`, 'Данные покупки', [
+      new TextInputBuilder().setCustomId('details').setLabel('Детали').setStyle(TextInputStyle.Paragraph).setRequired(true),
+    ]);
+    return interaction.showModal(modal);
+  }
+
+  return null;
+}
+
+async function handleShopModal(interaction) {
+  const [mode, itemKey] = interaction.customId.split(':');
+  const items = shopService.getItems();
+  const item = items[itemKey];
+  if (!item) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Товар не найден.')] });
+  }
+  const userData = pointsService.getUser(interaction.user.id);
+  if (userData.coins < item.price) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Недостаточно Coins').setDescription('Пополните баланс.')] });
+  }
+  if (mode === 'shop_auto') {
+    const roleName = interaction.fields.getTextInputValue('roleName');
+    const hexColor = interaction.fields.getTextInputValue('hexColor');
+    const iconLink = interaction.fields.getTextInputValue('iconLink');
+    const purchaseId = shopService.createPurchase({ userId: interaction.user.id, itemKey, price: item.price, details: { roleName, hexColor, iconLink } });
+    coinsService.adjustCoins({ actorId: interaction.user.id, targetId: interaction.user.id, delta: -item.price, reason: `Покупка ${item.name}`, kind: 'purchase' });
+    const role = await createCustomRole({
+      guild: interaction.guild,
+      member: await interaction.guild.members.fetch(interaction.user.id),
+      name: roleName,
+      color: hexColor,
+      icon: iconLink || null,
+    });
+    const expiresAt = Date.now() + item.durationDays * 24 * 60 * 60 * 1000;
+    shopService.updatePurchase(purchaseId, { status: 'active', roleId: role.id, expiresAt });
+    await sendStaffLog(interaction.client, infoEmbed('Магазин: покупка')
+      .setDescription(`AUTO товар: **${item.name}**\nПокупка #${purchaseId} для <@${interaction.user.id}>`));
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Покупка завершена').setDescription('Кастом роль создана.')] });
+  }
+
+  if (mode === 'shop_ticket') {
+    const details = interaction.fields.getTextInputValue('details');
+    const purchaseId = shopService.createPurchase({ userId: interaction.user.id, itemKey, price: item.price, details: { details } });
+    coinsService.adjustCoins({ actorId: interaction.user.id, targetId: interaction.user.id, delta: -item.price, reason: `Покупка ${item.name}`, kind: 'purchase' });
+    const ticket = await ticketService.createTicket({ client: interaction.client, purchaseId, buyerId: interaction.user.id, itemName: item.name, details });
+    shopService.updatePurchase(purchaseId, { ticketMessageId: ticket.messageId, ticketThreadId: ticket.threadId, status: 'pending' });
+    await sendStaffLog(interaction.client, infoEmbed('Магазин: создан тикет')
+      .setDescription(`TICKET товар: **${item.name}**\nПокупка #${purchaseId} для <@${interaction.user.id}>`));
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Заявка создана').setDescription('Ожидайте обработки.')] });
+  }
+
+  return null;
+}
+
+async function handleShopTicketButton(interaction) {
+  const [action, purchaseIdRaw] = interaction.customId.split(':');
+  const purchaseId = Number(purchaseIdRaw);
+  const purchase = shopService.getPurchase(purchaseId);
+  if (!purchase) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Покупка не найдена.')] });
+  }
+
+  if (action === 'shop_edit') {
+    if (purchase.userId !== interaction.user.id) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Вы не автор заявки.')] });
+    }
+    const modal = buildModal(`shop_edit:${purchaseId}`, 'Изменить данные', [
+      new TextInputBuilder().setCustomId('details').setLabel('Новые детали').setStyle(TextInputStyle.Paragraph).setRequired(true),
+    ]);
+    return interaction.showModal(modal);
+  }
+
+  if (action === 'shop_done') {
+    const check = assertStaff(interaction.member, 'ticket_done');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const item = shopService.getItems()[purchase.itemKey];
+    const expiresAt = Date.now() + item.durationDays * 24 * 60 * 60 * 1000;
+    shopService.updatePurchase(purchaseId, { status: 'active', handledBy: interaction.user.id, handledAt: Date.now(), expiresAt });
+    await sendStaffLog(interaction.client, successEmbed('Магазин: выполнено')
+      .setDescription(`Покупка #${purchaseId} выполнена <@${interaction.user.id}>`));
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription('Отмечено как выполнено.')] });
+  }
+
+  if (action === 'shop_deny') {
+    const check = assertStaff(interaction.member, 'ticket_deny');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    shopService.updatePurchase(purchaseId, { status: 'denied', handledBy: interaction.user.id, handledAt: Date.now() });
+    await sendStaffLog(interaction.client, errorEmbed('Магазин: отказ')
+      .setDescription(`Покупка #${purchaseId} отказана <@${interaction.user.id}>`));
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription('Покупка отклонена.')] });
+  }
+
+  if (action === 'shop_refund') {
+    const check = assertStaff(interaction.member, 'ticket_refund');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const result = shopService.refundPurchase(purchaseId, interaction.user.id, 'Возврат по тикету');
+    if (!result.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription(result.reason)] });
+    }
+    await sendStaffLog(interaction.client, infoEmbed('Магазин: возврат')
+      .setDescription(`Покупка #${purchaseId} возвращена <@${interaction.user.id}>`));
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Возврат выполнен').setDescription('Coins возвращены.')] });
+  }
+
+  return null;
+}
+
+async function handleShopEditModal(interaction) {
+  const purchaseId = Number(interaction.customId.split(':')[1]);
+  const purchase = shopService.getPurchase(purchaseId);
+  if (!purchase) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Покупка не найдена.')] });
+  }
+  if (purchase.userId !== interaction.user.id) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Вы не автор заявки.')] });
+  }
+  const details = interaction.fields.getTextInputValue('details');
+  shopService.updatePurchase(purchaseId, { detailsJson: JSON.stringify({ details }) });
+  return interaction.reply({ ephemeral: true, embeds: [successEmbed('Данные обновлены.')] });
+}
+
+client.once(Events.ClientReady, async () => {
+  logger.info(`Logged in as ${client.user.tag}`);
+  loadConfig();
+  initDb();
+});
+
+client.on(Events.GuildMemberAdd, (member) => {
+  pointsService.ensureUser(member.id);
+});
+
+client.on(Events.GuildMemberUpdate, (oldMember, newMember) => {
+  ensureStaffRoleRecord(newMember).catch(() => null);
+});
+
+client.on(Events.InteractionCreate, async (interaction) => {
+  const config = getConfig();
+  if (interaction.guildId !== config.guildId) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Гильдия не поддерживается.')] });
+  }
+
+  if (interaction.isChatInputCommand()) {
+    const command = client.commands.get(interaction.commandName);
+    if (!command) return;
+    try {
+      await command.execute(interaction);
+    } catch (error) {
+      logger.error(`Command error: ${error.message}`);
+      if (interaction.deferred || interaction.replied) {
+        await interaction.followUp({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Команда завершилась ошибкой.')] });
+      } else {
+        await interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Команда завершилась ошибкой.')] });
+      }
+    }
+    return;
+  }
+
+  if (interaction.isStringSelectMenu()) {
+    if (interaction.customId === 'shop_select') {
+      return handleShopSelect(interaction);
+    }
+    if (interaction.customId === 'panel_select') {
+      return handlePanelSelect(interaction);
+    }
+  }
+
+  if (interaction.isButton()) {
+    if (interaction.customId.startsWith('shop_')) {
+      return handleShopTicketButton(interaction);
+    }
+    if (interaction.customId.startsWith('promo_')) {
+      const [action, idRaw] = interaction.customId.split(':');
+      const check = assertStaff(interaction.member, action === 'promo_approve' ? 'promo_approve' : 'promo_deny');
+      if (!check.ok) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+      }
+      const request = promoService.getRequest(Number(idRaw));
+      if (!request) {
+        return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Заявка не найдена.')] });
+      }
+      promoService.reviewRequest(request.id, interaction.user.id, action === 'promo_approve' ? 'approved' : 'denied', '');
+      if (action === 'promo_approve') {
+        const guild = interaction.guild;
+        const target = await guild.members.fetch(request.userId).catch(() => null);
+        if (target) {
+          const ladderRoleIds = getConfig().roles.ladder.map((r) => r.roleId);
+          const rolesToRemove = target.roles.cache.filter((role) => ladderRoleIds.includes(role.id));
+          if (rolesToRemove.size > 0) {
+            await target.roles.remove(rolesToRemove, 'Смена стафф роли');
+          }
+          await target.roles.add(request.toRoleId, 'Смена стафф роли');
+          pointsService.setStaffRole(request.userId, request.toRoleId, Date.now());
+        }
+      }
+      return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription('Заявка обработана.')] });
+    }
+    if (interaction.customId.startsWith('panel_')) {
+      return handlePanelButton(interaction);
+    }
+  }
+
+  if (interaction.isModalSubmit()) {
+    if (interaction.customId.startsWith('shop_auto') || interaction.customId.startsWith('shop_ticket')) {
+      return handleShopModal(interaction);
+    }
+    if (interaction.customId.startsWith('shop_edit')) {
+      return handleShopEditModal(interaction);
+    }
+    if (interaction.customId.startsWith('panel_')) {
+      return handlePanelModal(interaction);
+    }
+  }
+});
+
+setInterval(() => {
+  warningsService.cleanupExpired();
+}, 24 * 60 * 60 * 1000);
+
+setInterval(async () => {
+  const rows = db.prepare('SELECT * FROM shop_purchases WHERE status = ? AND expiresAt IS NOT NULL AND expiresAt <= ?')
+    .all('active', Date.now());
+  for (const row of rows) {
+    if (row.roleId) {
+      const guild = await client.guilds.fetch(getConfig().guildId).catch(() => null);
+      if (guild) {
+        const member = await guild.members.fetch(row.userId).catch(() => null);
+        if (member) {
+          await removeCustomRole({ guild, member, roleId: row.roleId });
+        }
+      }
+    }
+    shopService.updatePurchase(row.id, { status: 'expired' });
+  }
+}, 5 * 60 * 1000);
+
+setInterval(() => {
+  const config = getConfig();
+  if (!config.autoCreateRequestOnEligible) return;
+  const staffRows = db.prepare('SELECT userId FROM users WHERE currentStaffRoleId IS NOT NULL').all();
+  for (const row of staffRows) {
+    const eligibility = promoService.getEligibility(row.userId);
+    if (eligibility.eligible) {
+      const existing = db.prepare('SELECT * FROM promo_requests WHERE userId = ? AND status = ?')
+        .get(row.userId, 'pending');
+      if (!existing) {
+        promoService.createRequest(row.userId);
+      }
+    }
+  }
+}, 10 * 60 * 1000);
+
+client.login(process.env.DISCORD_TOKEN);

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+function getLogStream() {
+  const logDir = path.join(__dirname, '..', 'logs');
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+  const date = new Date().toISOString().slice(0, 10);
+  const logPath = path.join(logDir, `bot-${date}.log`);
+  return fs.createWriteStream(logPath, { flags: 'a' });
+}
+
+const stream = getLogStream();
+
+function logLine(level, message) {
+  const line = `[${new Date().toISOString()}] [${level}] ${message}`;
+  stream.write(`${line}\n`);
+  // eslint-disable-next-line no-console
+  console.log(line);
+}
+
+module.exports = {
+  info: (message) => logLine('INFO', message),
+  warn: (message) => logLine('WARN', message),
+  error: (message) => logLine('ERROR', message),
+};

--- a/src/panel/handlers.js
+++ b/src/panel/handlers.js
@@ -1,0 +1,266 @@
+const {
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder,
+} = require('discord.js');
+const { assertStaff, hasStaffAccess, getStaffRank, getRoleKeyByRank } = require('../utils/permissions');
+const { successEmbed, errorEmbed, infoEmbed } = require('../utils/embeds');
+const pointsService = require('../services/pointsService');
+const coinsService = require('../services/coinsService');
+const punishService = require('../services/punishService');
+const promoService = require('../services/promoService');
+const { parseDuration } = require('../utils/timeParse');
+const logger = require('../logger');
+const { loadConfig, getConfig } = require('../config');
+
+function buildModal(customId, title, inputs) {
+  const modal = new ModalBuilder().setCustomId(customId).setTitle(title);
+  const rows = inputs.map((input) => new ActionRowBuilder().addComponents(input));
+  modal.addComponents(...rows);
+  return modal;
+}
+
+function handlePanelButton(interaction) {
+  const mapping = {
+    panel_sp_add: 'sp_add',
+    panel_sp_remove: 'sp_remove',
+    panel_sp_penalty: 'sp_penalty',
+    panel_coins: 'coins_add',
+    panel_mute: 'punish_mute',
+    panel_ban: 'punish_ban',
+    panel_revoke: 'punish_revoke',
+    panel_reload: 'config_reload',
+  };
+  const accessKey = mapping[interaction.customId];
+  if (accessKey) {
+    const check = assertStaff(interaction.member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+  }
+
+  if (interaction.customId === 'panel_sp_add' || interaction.customId === 'panel_sp_remove') {
+    const modal = buildModal(
+      interaction.customId,
+      interaction.customId === 'panel_sp_add' ? 'Начислить SP' : 'Списать SP',
+      [
+        new TextInputBuilder().setCustomId('target').setLabel('ID пользователя').setStyle(TextInputStyle.Short).setRequired(true),
+        new TextInputBuilder().setCustomId('value').setLabel('Количество').setStyle(TextInputStyle.Short).setRequired(true),
+        new TextInputBuilder().setCustomId('reason').setLabel('Причина').setStyle(TextInputStyle.Paragraph).setRequired(true),
+        new TextInputBuilder().setCustomId('meta').setLabel('metaType (опц.)').setStyle(TextInputStyle.Short).setRequired(false),
+      ]
+    );
+    return interaction.showModal(modal);
+  }
+
+  if (interaction.customId === 'panel_sp_penalty') {
+    const modal = buildModal('panel_sp_penalty', 'Штраф SP', [
+      new TextInputBuilder().setCustomId('target').setLabel('ID пользователя').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('type').setLabel('Тип штрафа').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('reason').setLabel('Причина').setStyle(TextInputStyle.Paragraph).setRequired(true),
+    ]);
+    return interaction.showModal(modal);
+  }
+
+  if (interaction.customId === 'panel_coins') {
+    const modal = buildModal('panel_coins', 'Начислить/списать Coins', [
+      new TextInputBuilder().setCustomId('target').setLabel('ID пользователя').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('value').setLabel('Delta (+/-)').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('reason').setLabel('Причина').setStyle(TextInputStyle.Paragraph).setRequired(true),
+    ]);
+    return interaction.showModal(modal);
+  }
+
+  if (interaction.customId === 'panel_mute' || interaction.customId === 'panel_ban') {
+    const modal = buildModal(interaction.customId, interaction.customId === 'panel_mute' ? 'Мут' : 'Бан', [
+      new TextInputBuilder().setCustomId('target').setLabel('ID пользователя').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('duration').setLabel('Длительность (10m/2h/1d/perm)').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('reason').setLabel('Причина').setStyle(TextInputStyle.Paragraph).setRequired(true),
+      new TextInputBuilder().setCustomId('proof').setLabel('Доказательство (ссылка)').setStyle(TextInputStyle.Short).setRequired(interaction.customId === 'panel_ban'),
+    ]);
+    return interaction.showModal(modal);
+  }
+
+  if (interaction.customId === 'panel_revoke') {
+    const modal = buildModal('panel_revoke', 'Отменить наказание', [
+      new TextInputBuilder().setCustomId('caseId').setLabel('ID кейса').setStyle(TextInputStyle.Short).setRequired(true),
+      new TextInputBuilder().setCustomId('reason').setLabel('Причина').setStyle(TextInputStyle.Paragraph).setRequired(true),
+    ]);
+    return interaction.showModal(modal);
+  }
+
+  if (interaction.customId === 'panel_reload') {
+    loadConfig();
+    return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Конфигурация перезагружена.')] });
+  }
+
+  return null;
+}
+
+async function handlePanelModal(interaction) {
+  const member = interaction.member;
+  const userId = interaction.user.id;
+  if (interaction.customId === 'panel_sp_add' || interaction.customId === 'panel_sp_remove') {
+    const check = assertStaff(member, interaction.customId === 'panel_sp_add' ? 'sp_add' : 'sp_remove');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const targetId = interaction.fields.getTextInputValue('target');
+    if (targetId === userId) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Нельзя начислять или списывать себе.')] });
+    }
+    const value = Number(interaction.fields.getTextInputValue('value'));
+    const reason = interaction.fields.getTextInputValue('reason');
+    const metaType = interaction.fields.getTextInputValue('meta') || '';
+    if (Number.isNaN(value) || value <= 0) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Некорректное значение.')] });
+    }
+    const delta = interaction.customId === 'panel_sp_add' ? value : -value;
+    if (metaType && !pointsService.canAwardMeta(userId, metaType)) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Дневной лимит по metaType исчерпан.')] });
+    }
+    pointsService.adjustSp({ actorId: userId, targetId, delta, reason, kind: 'manual', metaType });
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`SP изменены на ${delta}.`)] });
+  }
+
+  if (interaction.customId === 'panel_sp_penalty') {
+    const check = assertStaff(member, 'sp_penalty');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const targetId = interaction.fields.getTextInputValue('target');
+    const type = interaction.fields.getTextInputValue('type');
+    const reason = interaction.fields.getTextInputValue('reason');
+    const penalties = {
+      ignore: -5,
+      rude: -6,
+      wrong_punish: -8,
+      confirmed_complaint: -12,
+      abuse_power: -25,
+    };
+    const delta = penalties[type];
+    if (!delta) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Неизвестный тип штрафа.')] });
+    }
+    pointsService.adjustSp({ actorId: userId, targetId, delta, reason, kind: 'penalty', metaType: type });
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Штраф применён').setDescription(`SP ${delta}.`)] });
+  }
+
+  if (interaction.customId === 'panel_coins') {
+    const check = assertStaff(member, 'coins_add');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const targetId = interaction.fields.getTextInputValue('target');
+    if (targetId === userId) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Нельзя начислять или списывать себе.')] });
+    }
+    const delta = Number(interaction.fields.getTextInputValue('value'));
+    const reason = interaction.fields.getTextInputValue('reason');
+    if (Number.isNaN(delta) || delta === 0) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Некорректное значение.')] });
+    }
+    const softLimitExceeded = coinsService.checkSoftLimit(userId, delta);
+    coinsService.adjustCoins({ actorId: userId, targetId, delta, reason, kind: 'manual' });
+    if (softLimitExceeded) {
+      logger.warn(`Coins daily soft limit exceeded by ${userId}.`);
+      const config = getConfig();
+      const channel = await interaction.client.channels.fetch(config.channels.staffJournal);
+      await channel.send({ embeds: [infoEmbed('⚠ Превышен лимит Coins').setDescription(`Актёр: <@${userId}>\\nDelta: ${delta}`)] });
+    }
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription(`Coins изменены на ${delta}.`)] });
+  }
+
+  if (interaction.customId === 'panel_mute' || interaction.customId === 'panel_ban') {
+    const accessKey = interaction.customId === 'panel_mute' ? 'punish_mute' : 'punish_ban';
+    const check = assertStaff(member, accessKey);
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const targetId = interaction.fields.getTextInputValue('target');
+    const duration = interaction.fields.getTextInputValue('duration');
+    const reason = interaction.fields.getTextInputValue('reason');
+    const proof = interaction.fields.getTextInputValue('proof');
+
+    const roleKey = getRoleKeyByRank(getStaffRank(member));
+    const limitCheck = punishService.checkLimit(roleKey, interaction.customId === 'panel_mute' ? 'mute' : 'ban', duration);
+    if (!limitCheck.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Отказ').setDescription(limitCheck.reason)] });
+    }
+    const parsed = parseDuration(duration);
+    punishService.logCase({
+      actorId: userId,
+      targetId,
+      action: interaction.customId === 'panel_mute' ? 'mute' : 'ban',
+      durationMinutes: parsed.minutes,
+      isPerm: parsed.isPerm,
+      reason,
+      proof,
+    });
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Наказание записано').setDescription('Выполните действие через модерацию.')] });
+  }
+
+  if (interaction.customId === 'panel_revoke') {
+    const check = assertStaff(member, 'punish_revoke');
+    if (!check.ok) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+    }
+    const caseId = Number(interaction.fields.getTextInputValue('caseId'));
+    const reason = interaction.fields.getTextInputValue('reason');
+    if (Number.isNaN(caseId)) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Ошибка').setDescription('Некорректный ID кейса.')] });
+    }
+    punishService.revokeCase(caseId, userId, reason);
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Готово').setDescription('Кейс отозван.')] });
+  }
+
+  if (interaction.customId === 'panel_reload') {
+    if (!hasStaffAccess(member, 'config_reload')) {
+      return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription('Недостаточно прав.')] });
+    }
+    return interaction.reply({ ephemeral: true, embeds: [successEmbed('Конфиг обновлён.')] });
+  }
+
+  return null;
+}
+
+async function handlePanelSelect(interaction) {
+  const check = assertStaff(interaction.member, 'profile_me');
+  if (!check.ok) {
+    return interaction.reply({ ephemeral: true, embeds: [errorEmbed('Доступ запрещён').setDescription(check.reason)] });
+  }
+  const value = interaction.values[0];
+  if (value === 'top_sp') {
+    const top = pointsService.topSp(10);
+    const description = top.map((row, index) => `**${index + 1}.** <@${row.userId}> — ${row.sp} SP`).join('\n');
+    return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Топ SP').setDescription(description || 'Нет данных.')] });
+  }
+  if (value === 'top_coins') {
+    const top = coinsService.topCoins(10);
+    const description = top.map((row, index) => `**${index + 1}.** <@${row.userId}> — ${row.coins} Coins`).join('\n');
+    return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Топ Coins').setDescription(description || 'Нет данных.')] });
+  }
+  if (value === 'profile_me') {
+    const user = pointsService.getUser(interaction.user.id);
+    return interaction.reply({
+      ephemeral: true,
+      embeds: [infoEmbed('Профиль').setDescription(`SP: **${user.sp}**\nCoins: **${user.coins}**`)],
+    });
+  }
+  if (value === 'profile_user') {
+    return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Профиль').setDescription('Используйте /profile user.')] });
+  }
+  if (value === 'profile_promos') {
+    const requests = promoService.listRequests('pending');
+    const description = requests.map((req) => `#${req.id} <@${req.userId}>`).join('\n') || 'Нет заявок.';
+    return interaction.reply({ ephemeral: true, embeds: [infoEmbed('Заявки').setDescription(description)] });
+  }
+  return null;
+}
+
+module.exports = {
+  handlePanelButton,
+  handlePanelModal,
+  handlePanelSelect,
+};

--- a/src/panel/panelMessage.js
+++ b/src/panel/panelMessage.js
@@ -1,0 +1,46 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder } = require('discord.js');
+const { infoEmbed } = require('../utils/embeds');
+
+function buildPanelMessage() {
+  const embed = infoEmbed('Панель стаффа')
+    .setDescription('Быстрые действия стаффа.');
+
+  const row1 = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId('panel_sp_add').setLabel('➕ SP').setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId('panel_sp_remove').setLabel('➖ SP').setStyle(ButtonStyle.Danger),
+    new ButtonBuilder().setCustomId('panel_sp_penalty').setLabel('🧾 Штраф').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('panel_coins').setLabel('🪙 Coins').setStyle(ButtonStyle.Primary)
+  );
+
+  const row2 = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId('panel_shop').setLabel('🛒 Магазин').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('panel_profile').setLabel('📈 Профиль').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('panel_top').setLabel('🏅 Топ SP/Coins').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('panel_promos').setLabel('🧾 Заявки').setStyle(ButtonStyle.Secondary)
+  );
+
+  const row3 = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId('panel_mute').setLabel('🔇 Мут').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('panel_ban').setLabel('🚫 Бан').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('panel_revoke').setLabel('♻️ Отменить наказание').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('panel_reload').setLabel('⚙️ Reload').setStyle(ButtonStyle.Primary)
+  );
+
+  const row4 = new ActionRowBuilder().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId('panel_select')
+      .setPlaceholder('Быстрые действия')
+      .addOptions([
+        { label: 'Профиль: я', value: 'profile_me' },
+        { label: 'Профиль: выбрать', value: 'profile_user' },
+        { label: 'Топ SP', value: 'top_sp' },
+        { label: 'Топ Coins', value: 'top_coins' },
+      ])
+  );
+
+  return { embeds: [embed], components: [row1, row2, row3, row4] };
+}
+
+module.exports = {
+  buildPanelMessage,
+};

--- a/src/registerCommands.js
+++ b/src/registerCommands.js
@@ -1,0 +1,46 @@
+require('dotenv').config();
+const { REST, Routes } = require('discord.js');
+const { loadConfig } = require('./config');
+const profile = require('./commands/profile');
+const sp = require('./commands/sp');
+const coins = require('./commands/coins');
+const promo = require('./commands/promo');
+const punish = require('./commands/punish');
+const shop = require('./commands/shop');
+const panel = require('./commands/panel');
+const configCmd = require('./commands/config');
+const warnings = require('./commands/warnings');
+const backup = require('./commands/backup');
+const health = require('./commands/health');
+
+const config = loadConfig();
+
+const commands = [
+  profile.data.toJSON(),
+  sp.data.toJSON(),
+  coins.data.toJSON(),
+  promo.data.toJSON(),
+  punish.data.toJSON(),
+  warnings.data.toJSON(),
+  shop.data.toJSON(),
+  panel.data.toJSON(),
+  configCmd.data.toJSON(),
+  backup.data.toJSON(),
+  health.data.toJSON(),
+];
+
+const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+
+(async () => {
+  try {
+    await rest.put(
+      Routes.applicationGuildCommands(process.env.CLIENT_ID, config.guildId),
+      { body: commands }
+    );
+    // eslint-disable-next-line no-console
+    console.log('Команды зарегистрированы.');
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Ошибка регистрации команд:', error);
+  }
+})();

--- a/src/services/coinsService.js
+++ b/src/services/coinsService.js
@@ -1,0 +1,51 @@
+const { db } = require('../db');
+const { getConfig } = require('../config');
+const { ensureUser, getUser } = require('./pointsService');
+
+function adjustCoins({ actorId, targetId, delta, reason, kind = 'manual' }) {
+  ensureUser(targetId);
+  db.prepare('UPDATE users SET coins = coins + ? WHERE userId = ?').run(delta, targetId);
+  db.prepare(`
+    INSERT INTO coins_log (ts, actorId, targetId, delta, reason, kind)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(Date.now(), actorId, targetId, delta, reason, kind);
+}
+
+function setCoins({ actorId, targetId, value, reason }) {
+  ensureUser(targetId);
+  const current = getUser(targetId).coins;
+  const delta = value - current;
+  adjustCoins({ actorId, targetId, delta, reason, kind: 'set' });
+}
+
+function listCoinsLog(limit = 20, targetId = null) {
+  if (targetId) {
+    return db.prepare('SELECT * FROM coins_log WHERE targetId = ? ORDER BY ts DESC LIMIT ?').all(targetId, limit);
+  }
+  return db.prepare('SELECT * FROM coins_log ORDER BY ts DESC LIMIT ?').all(limit);
+}
+
+function topCoins(limit = 10) {
+  return db.prepare('SELECT userId, coins FROM users ORDER BY coins DESC LIMIT ?').all(limit);
+}
+
+function checkSoftLimit(actorId, delta) {
+  const config = getConfig();
+  if (delta <= 0) return false;
+  const dayKey = new Date().toISOString().slice(0, 10);
+  const start = new Date(`${dayKey}T00:00:00Z`).getTime();
+  const row = db.prepare(`
+    SELECT SUM(delta) as sum FROM coins_log
+    WHERE actorId = ? AND delta > 0 AND ts >= ?
+  `).get(actorId, start);
+  const sum = row?.sum ?? 0;
+  return sum + delta > (config.coins?.dailySoftLimit ?? 80);
+}
+
+module.exports = {
+  adjustCoins,
+  setCoins,
+  listCoinsLog,
+  topCoins,
+  checkSoftLimit,
+};

--- a/src/services/customRoleService.js
+++ b/src/services/customRoleService.js
@@ -1,0 +1,34 @@
+const { getConfig } = require('../config');
+
+async function createCustomRole({ guild, member, name, color, icon }) {
+  const role = await guild.roles.create({
+    name,
+    color,
+    icon: icon || null,
+    reason: 'Магазин: кастом роль',
+  });
+  await member.roles.add(role.id, 'Магазин: кастом роль');
+  return role;
+}
+
+async function removeCustomRole({ guild, member, roleId }) {
+  const role = await guild.roles.fetch(roleId).catch(() => null);
+  if (role) {
+    await member.roles.remove(role.id, 'Магазин: истекла кастом роль').catch(() => null);
+    await role.delete('Магазин: истекла кастом роль').catch(() => null);
+  }
+}
+
+async function hasActiveCustomRole({ guild, member }) {
+  const config = getConfig();
+  const items = config.shop.items;
+  const roleIds = new Set(Object.values(items).map((item) => item.roleId).filter(Boolean));
+  const match = member.roles.cache.find((r) => roleIds.has(r.id));
+  return Boolean(match);
+}
+
+module.exports = {
+  createCustomRole,
+  removeCustomRole,
+  hasActiveCustomRole,
+};

--- a/src/services/pointsService.js
+++ b/src/services/pointsService.js
@@ -1,0 +1,96 @@
+const { db } = require('../db');
+const { getConfig } = require('../config');
+const { addWarning } = require('./warningsService');
+
+function ensureUser(userId) {
+  const row = db.prepare('SELECT userId FROM users WHERE userId = ?').get(userId);
+  if (!row) {
+    db.prepare('INSERT INTO users (userId, sp, coins, joinedAt) VALUES (?, 0, 0, ?)')
+      .run(userId, Date.now());
+  }
+}
+
+function getUser(userId) {
+  ensureUser(userId);
+  return db.prepare('SELECT * FROM users WHERE userId = ?').get(userId);
+}
+
+function setStaffRole(userId, roleId, sinceTs) {
+  ensureUser(userId);
+  db.prepare('UPDATE users SET currentStaffRoleId = ?, staffRoleSince = ? WHERE userId = ?')
+    .run(roleId, sinceTs, userId);
+}
+
+function adjustSp({ actorId, targetId, delta, reason, proof = '', kind = 'manual', metaType = '' }) {
+  ensureUser(targetId);
+  db.prepare('UPDATE users SET sp = sp + ? WHERE userId = ?').run(delta, targetId);
+  db.prepare(`
+    INSERT INTO sp_log (ts, actorId, targetId, delta, reason, proof, kind, metaType)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(Date.now(), actorId, targetId, delta, reason, proof, kind, metaType);
+  evaluateThresholds(targetId, actorId);
+}
+
+function setSp({ actorId, targetId, value, reason }) {
+  ensureUser(targetId);
+  const current = getUser(targetId).sp;
+  const delta = value - current;
+  adjustSp({ actorId, targetId, delta, reason, kind: 'set' });
+}
+
+function listSpLog(limit = 20, targetId = null) {
+  if (targetId) {
+    return db.prepare('SELECT * FROM sp_log WHERE targetId = ? ORDER BY ts DESC LIMIT ?').all(targetId, limit);
+  }
+  return db.prepare('SELECT * FROM sp_log ORDER BY ts DESC LIMIT ?').all(limit);
+}
+
+function topSp(limit = 10) {
+  return db.prepare('SELECT userId, sp FROM users ORDER BY sp DESC LIMIT ?').all(limit);
+}
+
+function getDailyMetaCount(actorId, metaType) {
+  const dayKey = new Date().toISOString().slice(0, 10);
+  const row = db.prepare(`
+    SELECT COUNT(*) as cnt FROM sp_log
+    WHERE actorId = ? AND metaType = ? AND ts >= ?
+  `).get(actorId, metaType, new Date(`${dayKey}T00:00:00Z`).getTime());
+  return row?.cnt ?? 0;
+}
+
+function canAwardMeta(actorId, metaType) {
+  const config = getConfig();
+  const count = getDailyMetaCount(actorId, metaType);
+  return count < (config.metaTypeDailyLimit ?? 3);
+}
+
+function evaluateThresholds(targetId, actorId) {
+  const user = getUser(targetId);
+  if (user.sp <= -30) {
+    addWarning({ actorId, userId: targetId, type: 'auto', reason: 'Авто-предупреждение: SP <= -30' });
+  }
+  if (user.sp <= -50) {
+    const config = getConfig();
+    const ladder = config.roles.ladder;
+    const currentIndex = ladder.findIndex((role) => role.roleId === user.currentStaffRoleId);
+    if (currentIndex > 0) {
+      const newRole = ladder[currentIndex - 1];
+      setStaffRole(targetId, newRole.roleId, Date.now());
+      db.prepare(`
+        INSERT INTO sp_log (ts, actorId, targetId, delta, reason, proof, kind, metaType)
+        VALUES (?, ?, ?, 0, ?, '', 'auto', 'auto_demote')
+      `).run(Date.now(), actorId, targetId, 'Авто-понижение: SP <= -50');
+    }
+  }
+}
+
+module.exports = {
+  ensureUser,
+  getUser,
+  setStaffRole,
+  adjustSp,
+  setSp,
+  listSpLog,
+  topSp,
+  canAwardMeta,
+};

--- a/src/services/promoService.js
+++ b/src/services/promoService.js
@@ -1,0 +1,89 @@
+const { db } = require('../db');
+const { getConfig } = require('../config');
+const { getUser, ensureUser, setStaffRole } = require('./pointsService');
+const { hasActiveWarning } = require('./warningsService');
+
+function getRoleKeyById(roleId) {
+  const config = getConfig();
+  return config.roles.ladder.find((role) => role.roleId === roleId)?.key ?? null;
+}
+
+function getRoleByKey(roleKey) {
+  const config = getConfig();
+  return config.roles.ladder.find((role) => role.key === roleKey) ?? null;
+}
+
+function getEligibility(userId) {
+  const config = getConfig();
+  const user = getUser(userId);
+  const currentKey = getRoleKeyById(user.currentStaffRoleId);
+  if (!currentKey) {
+    return { eligible: false, reason: 'Стафф роль не найдена.' };
+  }
+  const rule = config.promotions.table[currentKey];
+  if (!rule) {
+    return { eligible: false, reason: 'Для этой роли нет автоповышения.' };
+  }
+  if (hasActiveWarning(userId)) {
+    return { eligible: false, reason: 'Есть активное предупреждение.' };
+  }
+  const daysInRole = user.staffRoleSince
+    ? Math.floor((Date.now() - user.staffRoleSince) / (24 * 60 * 60 * 1000))
+    : 0;
+  if (user.sp < rule.sp) {
+    return { eligible: false, reason: `Недостаточно SP (${user.sp}/${rule.sp}).` };
+  }
+  if (daysInRole < rule.days) {
+    return { eligible: false, reason: `Недостаточно дней (${daysInRole}/${rule.days}).` };
+  }
+  return { eligible: true, fromRoleId: user.currentStaffRoleId, toRoleId: getRoleByKey(rule.to)?.roleId };
+}
+
+function createRequest(userId) {
+  ensureUser(userId);
+  const eligibility = getEligibility(userId);
+  if (!eligibility.eligible) {
+    return { ok: false, reason: eligibility.reason };
+  }
+  const user = getUser(userId);
+  const daysAt = user.staffRoleSince
+    ? Math.floor((Date.now() - user.staffRoleSince) / (24 * 60 * 60 * 1000))
+    : 0;
+  const info = db.prepare(`
+    INSERT INTO promo_requests (ts, userId, fromRoleId, toRoleId, spAt, daysAt, status)
+    VALUES (?, ?, ?, ?, ?, ?, 'pending')
+  `).run(Date.now(), userId, eligibility.fromRoleId, eligibility.toRoleId, user.sp, daysAt);
+  return { ok: true, requestId: info.lastInsertRowid, eligibility };
+}
+
+function listRequests(status = 'pending') {
+  return db.prepare('SELECT * FROM promo_requests WHERE status = ? ORDER BY ts DESC').all(status);
+}
+
+function getRequest(id) {
+  return db.prepare('SELECT * FROM promo_requests WHERE id = ?').get(id);
+}
+
+function reviewRequest(id, reviewerId, status, note = '') {
+  db.prepare(`
+    UPDATE promo_requests SET status = ?, reviewerId = ?, reviewedAt = ?, note = ? WHERE id = ?
+  `).run(status, reviewerId, Date.now(), note, id);
+}
+
+function promoteUser(userId, toRoleId) {
+  setStaffRole(userId, toRoleId, Date.now());
+}
+
+function demoteUser(userId, toRoleId) {
+  setStaffRole(userId, toRoleId, Date.now());
+}
+
+module.exports = {
+  getEligibility,
+  createRequest,
+  listRequests,
+  getRequest,
+  reviewRequest,
+  promoteUser,
+  demoteUser,
+};

--- a/src/services/punishService.js
+++ b/src/services/punishService.js
@@ -1,0 +1,148 @@
+const { db } = require('../db');
+const { getConfig } = require('../config');
+const { parseDuration } = require('../utils/timeParse');
+const { adjustSp } = require('./pointsService');
+
+function getDayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getCounters(actorId) {
+  const dayKey = getDayKey();
+  let row = db.prepare('SELECT * FROM punish_sp_counters WHERE actorId = ? AND dayKey = ?')
+    .get(actorId, dayKey);
+  if (!row) {
+    db.prepare('INSERT INTO punish_sp_counters (actorId, dayKey, mutesCount, bansCount) VALUES (?, ?, 0, 0)')
+      .run(actorId, dayKey);
+    row = db.prepare('SELECT * FROM punish_sp_counters WHERE actorId = ? AND dayKey = ?')
+      .get(actorId, dayKey);
+  }
+  return row;
+}
+
+function incrementCounter(actorId, type) {
+  const dayKey = getDayKey();
+  if (type === 'mute') {
+    db.prepare('UPDATE punish_sp_counters SET mutesCount = mutesCount + 1 WHERE actorId = ? AND dayKey = ?')
+      .run(actorId, dayKey);
+  } else if (type === 'ban') {
+    db.prepare('UPDATE punish_sp_counters SET bansCount = bansCount + 1 WHERE actorId = ? AND dayKey = ?')
+      .run(actorId, dayKey);
+  }
+}
+
+function logCase({ actorId, targetId, action, durationMinutes, isPerm, reason, proof }) {
+  const info = db.prepare(`
+    INSERT INTO punish_cases (ts, actorId, targetId, action, durationMinutes, isPerm, reason, proof, revoked)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
+  `).run(Date.now(), actorId, targetId, action, durationMinutes, isPerm ? 1 : 0, reason, proof || '');
+  return info.lastInsertRowid;
+}
+
+function revokeCase(id, actorId, reason) {
+  db.prepare('UPDATE punish_cases SET revoked = 1, revokedAt = ?, revokedReason = ? WHERE id = ?')
+    .run(Date.now(), reason, id);
+}
+
+function listCases(limit = 20) {
+  return db.prepare('SELECT * FROM punish_cases ORDER BY ts DESC LIMIT ?').all(limit);
+}
+
+function getLimitKeyForRole(configLimits, roleKey) {
+  const keys = Object.keys(configLimits);
+  if (keys.includes(roleKey)) return roleKey;
+  return null;
+}
+
+function checkLimit(roleKey, action, durationInput) {
+  const config = getConfig();
+  const limits = config.punish.limits[action];
+  if (!limits) return { ok: false, reason: 'Лимиты не настроены.' };
+  const limitKey = getLimitKeyForRole(limits, roleKey);
+  if (!limitKey) {
+    return { ok: false, reason: 'Недостаточно прав на это наказание.' };
+  }
+  const parsed = parseDuration(durationInput);
+  const allowed = parseDuration(limits[limitKey]);
+  if (allowed.isPerm) {
+    return { ok: true, parsed };
+  }
+  if (parsed.isPerm) {
+    return { ok: false, reason: 'Перм наказание запрещено для вашей роли.' };
+  }
+  if (parsed.minutes === null) {
+    return { ok: false, reason: 'Неверный формат длительности.' };
+  }
+  if (parsed.minutes > allowed.minutes) {
+    return { ok: false, reason: 'Превышен лимит наказания.' };
+  }
+  return { ok: true, parsed };
+}
+
+function calculateSpForMute(minutes) {
+  if (minutes <= 10) return 1;
+  if (minutes <= 30) return 2;
+  if (minutes <= 120) return 3;
+  if (minutes <= 1440) return 4;
+  return 0;
+}
+
+function calculateSpForBan(minutes, isPerm) {
+  if (isPerm) return 12;
+  if (minutes <= 1440) return 5;
+  if (minutes <= 4320) return 7;
+  if (minutes <= 10080) return 9;
+  return 0;
+}
+
+function awardPunishSp({ actorId, targetId, action, minutes, isPerm, proof, logger }) {
+  const config = getConfig();
+  const counters = getCounters(actorId);
+  const cooldownHours = config.sameTargetCooldownHours ?? 24;
+  const since = Date.now() - cooldownHours * 60 * 60 * 1000;
+  const recent = db.prepare(`
+    SELECT COUNT(*) as cnt FROM sp_log
+    WHERE actorId = ? AND targetId = ? AND metaType = ? AND ts >= ?
+  `).get(actorId, targetId, action, since);
+  if ((recent?.cnt ?? 0) > 0) {
+    logger?.warn?.('SP cooldown triggered for punish.');
+    return { awarded: false, reason: 'Кулдаун на SP за того же нарушителя.' };
+  }
+
+  if (action === 'mute') {
+    if (counters.mutesCount >= 3) {
+      return { awarded: false, reason: 'Лимит SP за муты на сегодня исчерпан.' };
+    }
+    const sp = calculateSpForMute(minutes);
+    if (sp > 0) {
+      adjustSp({ actorId, targetId: actorId, delta: sp, reason: `SP за мут (${minutes}m)`, kind: 'auto', metaType: 'mute' });
+      incrementCounter(actorId, 'mute');
+      return { awarded: true, sp };
+    }
+  }
+
+  if (action === 'ban') {
+    if (!proof) {
+      return { awarded: false, reason: 'Для бана требуется доказательство.' };
+    }
+    if (counters.bansCount >= 2) {
+      return { awarded: false, reason: 'Лимит SP за баны на сегодня исчерпан.' };
+    }
+    const sp = calculateSpForBan(minutes, isPerm);
+    if (sp > 0) {
+      adjustSp({ actorId, targetId: actorId, delta: sp, reason: `SP за бан (${isPerm ? 'perm' : `${minutes}m`})`, kind: 'auto', metaType: 'ban' });
+      incrementCounter(actorId, 'ban');
+      return { awarded: true, sp };
+    }
+  }
+
+  return { awarded: false, reason: 'SP не начислены.' };
+}
+
+module.exports = {
+  logCase,
+  revokeCase,
+  listCases,
+  checkLimit,
+  awardPunishSp,
+};

--- a/src/services/shopService.js
+++ b/src/services/shopService.js
@@ -1,0 +1,78 @@
+const { db } = require('../db');
+const { getConfig } = require('../config');
+const { adjustCoins } = require('./coinsService');
+
+function getItems() {
+  return getConfig().shop.items;
+}
+
+function createPurchase({ userId, itemKey, price, details = {} }) {
+  const info = db.prepare(`
+    INSERT INTO shop_purchases (ts, userId, itemKey, price, status, detailsJson)
+    VALUES (?, ?, ?, ?, 'pending', ?)
+  `).run(Date.now(), userId, itemKey, price, JSON.stringify(details));
+  return info.lastInsertRowid;
+}
+
+function updatePurchase(id, fields) {
+  const updates = Object.keys(fields).map((key) => `${key} = ?`).join(', ');
+  const values = Object.values(fields);
+  db.prepare(`UPDATE shop_purchases SET ${updates} WHERE id = ?`).run(...values, id);
+}
+
+function setPurchaseStatus(id, status, handledBy = null) {
+  updatePurchase(id, { status, handledBy, handledAt: Date.now() });
+}
+
+function listPurchases(status = null, limit = 20) {
+  if (status) {
+    return db.prepare('SELECT * FROM shop_purchases WHERE status = ? ORDER BY ts DESC LIMIT ?')
+      .all(status, limit);
+  }
+  return db.prepare('SELECT * FROM shop_purchases ORDER BY ts DESC LIMIT ?').all(limit);
+}
+
+function listActivePurchases(limit = 20) {
+  return db.prepare('SELECT * FROM shop_purchases WHERE status = ? ORDER BY ts DESC LIMIT ?')
+    .all('active', limit);
+}
+
+function getPurchase(id) {
+  return db.prepare('SELECT * FROM shop_purchases WHERE id = ?').get(id);
+}
+
+function hasActivePurchase(userId, itemKey) {
+  const row = db.prepare('SELECT * FROM shop_purchases WHERE userId = ? AND itemKey = ? AND status = ?')\n    .get(userId, itemKey, 'active');
+  return Boolean(row);
+}
+
+function refundPurchase(id, actorId, reason) {
+  const purchase = getPurchase(id);
+  if (!purchase) return { ok: false, reason: 'Покупка не найдена.' };
+  if (purchase.status === 'refunded') return { ok: false, reason: 'Покупка уже возвращена.' };
+  adjustCoins({ actorId, targetId: purchase.userId, delta: purchase.price, reason: `Refund: ${reason}`, kind: 'refund' });
+  setPurchaseStatus(id, 'refunded', actorId);
+  return { ok: true, purchase };
+}
+
+function revokePurchase(id, actorId, reason) {
+  const purchase = getPurchase(id);
+  if (!purchase) return { ok: false, reason: 'Покупка не найдена.' };
+  if (purchase.status === 'revoked') return { ok: false, reason: 'Покупка уже откачена.' };
+  adjustCoins({ actorId, targetId: purchase.userId, delta: purchase.price, reason: `Revoke: ${reason}`, kind: 'revoke' });
+  setPurchaseStatus(id, 'revoked', actorId);
+  return { ok: true, purchase };
+}
+
+module.exports = {
+  getItems,
+  createPurchase,
+  updatePurchase,
+  setPurchaseStatus,
+  listPurchases,
+  listActivePurchases,
+  getPurchase,
+  hasActivePurchase,
+  refundPurchase,
+  revokePurchase,
+};

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -1,0 +1,43 @@
+const { ChannelType, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { getConfig } = require('../config');
+const { infoEmbed } = require('../utils/embeds');
+
+async function createTicket({ client, purchaseId, buyerId, itemName, details }) {
+  const config = getConfig();
+  const journal = await client.channels.fetch(config.channels.staffJournal);
+  const embed = infoEmbed('Магазин: заявка')
+    .setDescription(`Покупка **${itemName}**\nПокупатель: <@${buyerId}>\nID покупки: **${purchaseId}**`)
+    .addFields({ name: 'Детали', value: details || 'Не указано.' });
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`shop_done:${purchaseId}`)
+      .setLabel('✅ Выполнено')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`shop_deny:${purchaseId}`)
+      .setLabel('❌ Отказ')
+      .setStyle(ButtonStyle.Danger),
+    new ButtonBuilder()
+      .setCustomId(`shop_refund:${purchaseId}`)
+      .setLabel('↩ Возврат Coins')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(`shop_edit:${purchaseId}`)
+      .setLabel('🕒 Изменить данные')
+      .setStyle(ButtonStyle.Primary)
+  );
+
+  const message = await journal.send({ embeds: [embed], components: [row] });
+  const thread = await message.startThread({
+    name: `Тикет покупки #${purchaseId}`,
+    type: ChannelType.PrivateThread,
+    reason: 'Магазин: обработка заявки',
+  });
+  await thread.members.add(buyerId);
+  return { messageId: message.id, threadId: thread.id };
+}
+
+module.exports = {
+  createTicket,
+};

--- a/src/services/warningsService.js
+++ b/src/services/warningsService.js
@@ -1,0 +1,41 @@
+const { db } = require('../db');
+const { getConfig } = require('../config');
+
+function addWarning({ actorId, userId, type, reason }) {
+  const config = getConfig();
+  const now = Date.now();
+  const expiresAt = now + config.warnings.expireDays * 24 * 60 * 60 * 1000;
+  db.prepare(`
+    INSERT INTO warnings (userId, type, reason, createdAt, expiresAt, actorId)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(userId, type, reason, now, expiresAt, actorId);
+}
+
+function removeWarning(id) {
+  db.prepare('DELETE FROM warnings WHERE id = ?').run(id);
+}
+
+function listWarnings(userId = null) {
+  if (userId) {
+    return db.prepare('SELECT * FROM warnings WHERE userId = ? ORDER BY createdAt DESC').all(userId);
+  }
+  return db.prepare('SELECT * FROM warnings ORDER BY createdAt DESC').all();
+}
+
+function cleanupExpired() {
+  db.prepare('DELETE FROM warnings WHERE expiresAt <= ?').run(Date.now());
+}
+
+function hasActiveWarning(userId) {
+  const row = db.prepare('SELECT COUNT(*) as cnt FROM warnings WHERE userId = ? AND expiresAt > ?')
+    .get(userId, Date.now());
+  return (row?.cnt ?? 0) > 0;
+}
+
+module.exports = {
+  addWarning,
+  removeWarning,
+  listWarnings,
+  cleanupExpired,
+  hasActiveWarning,
+};

--- a/src/utils/embeds.js
+++ b/src/utils/embeds.js
@@ -1,0 +1,27 @@
+const { EmbedBuilder } = require('discord.js');
+
+function baseEmbed(title) {
+  return new EmbedBuilder()
+    .setTitle(title)
+    .setColor(0x2b2d31)
+    .setTimestamp(new Date());
+}
+
+function successEmbed(title) {
+  return baseEmbed(title).setColor(0x2ecc71);
+}
+
+function errorEmbed(title) {
+  return baseEmbed(title).setColor(0xe74c3c);
+}
+
+function infoEmbed(title) {
+  return baseEmbed(title).setColor(0x3498db);
+}
+
+module.exports = {
+  baseEmbed,
+  successEmbed,
+  errorEmbed,
+  infoEmbed,
+};

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,0 +1,56 @@
+const { getConfig } = require('../config');
+
+function getStaffRank(member) {
+  const config = getConfig();
+  const ladder = config.roles.ladder;
+  let topIndex = -1;
+  for (let i = 0; i < ladder.length; i += 1) {
+    const roleId = ladder[i].roleId;
+    if (member.roles.cache.has(roleId)) {
+      topIndex = i;
+    }
+  }
+  return topIndex;
+}
+
+function getRoleKeyByRank(rank) {
+  const config = getConfig();
+  if (rank < 0) return null;
+  return config.roles.ladder[rank]?.key ?? null;
+}
+
+function getRankByRoleKey(roleKey) {
+  const config = getConfig();
+  return config.roles.ladder.findIndex((role) => role.key === roleKey);
+}
+
+function hasStaffAccess(member, accessKey) {
+  const config = getConfig();
+  const requiredRoleKey = config.accessMatrix[accessKey];
+  if (!requiredRoleKey) return false;
+  const memberRank = getStaffRank(member);
+  if (memberRank < 0) return false;
+  const requiredRank = getRankByRoleKey(requiredRoleKey);
+  if (requiredRank < 0) return false;
+  return memberRank >= requiredRank;
+}
+
+function assertStaff(member, accessKey) {
+  if (!member) return { ok: false, reason: 'Команда доступна только стаффу.' };
+  const rank = getStaffRank(member);
+  if (rank < 0) {
+    return { ok: false, reason: 'Команда доступна только стаффу.' };
+  }
+  if (accessKey && !hasStaffAccess(member, accessKey)) {
+    return { ok: false, reason: 'Недостаточно прав для этой команды.' };
+  }
+  return { ok: true };
+}
+
+module.exports = {
+  getStaffRank,
+  getRoleKeyByRank,
+  getRankByRoleKey,
+  hasStaffAccess,
+  assertStaff,
+};

--- a/src/utils/timeParse.js
+++ b/src/utils/timeParse.js
@@ -1,0 +1,27 @@
+function parseDuration(input) {
+  if (!input) return { minutes: null, isPerm: false };
+  if (input === 'perm' || input === 'permanent') {
+    return { minutes: null, isPerm: true };
+  }
+  const match = String(input).trim().match(/^(\d+)(m|h|d)$/i);
+  if (!match) return { minutes: null, isPerm: false };
+  const value = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  let minutes = value;
+  if (unit === 'h') minutes = value * 60;
+  if (unit === 'd') minutes = value * 60 * 24;
+  return { minutes, isPerm: false };
+}
+
+function formatDuration(minutes, isPerm = false) {
+  if (isPerm) return 'perm';
+  if (minutes === null || minutes === undefined) return 'unknown';
+  if (minutes % (60 * 24) === 0) return `${minutes / (60 * 24)}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+}
+
+module.exports = {
+  parseDuration,
+  formatDuration,
+};


### PR DESCRIPTION
### Motivation
- Provide a complete staff-only Discord bot implementation matching the provided specification (Node.js 18+, discord.js v14, SQLite persistence, Russian messages, guild lock to GUILD_ID). 
- Enforce strict staff-only access and a role-ladder access matrix so only staff roles can use commands and UI.
- Support staff workflows: SP/Coins accounting, promotions (promo requests/approval), punishments, shop/tickets and audit logging to a single staff journal channel.

### Description
- Project scaffold: added `package.json`, `config.yml` (filled with IDs), `.env.example`, `README.md`, file-based logger (`src/logger.js`) and DB bootstrap (`src/db.js`) with the requested schema. 
- Command surface: implemented slash commands and handlers for `profile`, `sp`, `coins`, `promo`, `punish`, `shop`, `panel`, `warnings`, `backup`, `health` and a `registerCommands.js` helper to register guild commands. 
- Services & utils: implemented services for points/SP (`src/services/pointsService.js`), coins (`coinsService.js`), shop (`shopService.js`), tickets (`ticketService.js`), promo (`promoService.js`), punish logic (`punishService.js`), custom role lifecycle (`customRoleService.js`), warnings (`warningsService.js`), and utilities for config loading, embeds, time parsing and permissions/rank (`src/config.js`, `src/utils/*.js`). 
- UI & flows: panel message builder and interaction handlers (`src/panel/*`) with buttons/selects/modals, shop AUTO vs TICKET flows (auto role creation, staff-ticket creation + private thread), promotion request creation + journal buttons, purchase life-cycle and scheduled expiration tasks, and logging to `channels.staffJournal`. 

### Testing
- Automated tests: none were run as part of this change (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f545b4208330a9ebef8124cf094c)